### PR TITLE
chore: deprecated syntax

### DIFF
--- a/.github/workflows/python_package.yaml
+++ b/.github/workflows/python_package.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/bal_tools/safe_tx_builder/safe_tx_builder.py
+++ b/bal_tools/safe_tx_builder/safe_tx_builder.py
@@ -42,7 +42,7 @@ class SafeTxBuilder:
         ).flatbook
         self.safe_address = self._resolve_address(safe_address)
         self.version = version
-        self.timestamp = timestamp if timestamp else datetime.utcnow().timestamp()
+        self.timestamp = timestamp if timestamp else datetime.now(datetime.UTC)
         self.tx_builder_version = tx_builder_version
         self.base_payload = self.load_template(TemplateType.BASE)
         self._load_payload_metadata()

--- a/bal_tools/safe_tx_builder/safe_tx_builder.py
+++ b/bal_tools/safe_tx_builder/safe_tx_builder.py
@@ -1,5 +1,5 @@
 from typing import Optional, Union
-from datetime import datetime
+from datetime import datetime, timezone
 import os
 
 from bal_addresses import AddrBook
@@ -42,7 +42,7 @@ class SafeTxBuilder:
         ).flatbook
         self.safe_address = self._resolve_address(safe_address)
         self.version = version
-        self.timestamp = timestamp if timestamp else datetime.now(datetime.UTC)
+        self.timestamp = timestamp if timestamp else datetime.now(timezone.utc)
         self.tx_builder_version = tx_builder_version
         self.base_payload = self.load_template(TemplateType.BASE)
         self._load_payload_metadata()
@@ -69,7 +69,7 @@ class SafeTxBuilder:
     def _load_payload_metadata(self):
         self.base_payload.version = self.version
         self.base_payload.chainId = self.chain_id
-        self.base_payload.createdAt = int(self.timestamp)
+        self.base_payload.createdAt = int(self.timestamp.timestamp())
         self.base_payload.meta.txBuilderVersion = self.tx_builder_version
         self.base_payload.meta.createdFromSafeAddress = self.safe_address
 


### PR DESCRIPTION
```
  /Users/gosuto/Documents/_maxis/bal_tools/bal_tools/safe_tx_builder/safe_tx_builder.py:45: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    self.timestamp = timestamp if timestamp else datetime.utcnow().timestamp()
```