### PR TITLE
add json templates to pkg data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = "0.0.6"
+VERSION = "0.1.1"
 DESCRIPTION = "Balancer Tools"
 LONG_DESCRIPTION = "Balancer Maxi helper and ecosystem tools"
 
@@ -13,7 +13,7 @@ setup(
     long_description=LONG_DESCRIPTION,
     packages=find_packages(),
     include_package_data=True,  # Automatically include non-Python files
-    package_data={"bal_tools": ["abi/*.json", "graphql/**/*.gql"]},
+    package_data={"bal_tools": ["abi/*.json", "graphql/**/*.gql", "safe_tx_builder/templates/*.json"]},
     url="https://github.com/BalancerMaxis/bal_tools",
     install_requires=[
         "setuptools>=42",


### PR DESCRIPTION
when pip installing, the package doesnt include the required json template files for the tx builder. this includes them in the release