### PR TITLE
perf: do not fetch schema

### DIFF
--- a/bal_tools/subgraph.py
+++ b/bal_tools/subgraph.py
@@ -209,7 +209,7 @@ class Subgraph:
         transport = RequestsHTTPTransport(
             url=url or self.subgraph_url[subgraph], retries=retries
         )
-        client = Client(transport=transport, fetch_schema_from_transport=True)
+        client = Client(transport=transport, fetch_schema_from_transport=False)
 
         # retrieve the query from its file and execute it
         with open(f"{graphql_base_path}/{subgraph}/{query}.gql") as f:


### PR DESCRIPTION
mitigates performance issues encountered in `bal_addresses`:
```
    raise TransportQueryError(
gql.transport.exceptions.TransportQueryError: Error while fetching schema: {'message': 'bad indexers: {0xbdfb5ee5a2abf4fc7bb1bd1221067aef7f9de491: BadResponse(500)}'}
If you don't need the schema, you can try with: "fetch_schema_from_transport=False"
```

see https://github.com/graphql-python/gql/issues/331 and https://gql.readthedocs.io/en/latest/modules/client.html