### PR TITLE
add warning if GRAPH_API_KEY not set

### DIFF
--- a/bal_tools/errors.py
+++ b/bal_tools/errors.py
@@ -16,3 +16,6 @@ class GraphQLRequestError(Exception):
 
 class UnexpectedListLengthError(Exception):
     pass
+
+class NoPricesFoundError(Exception):
+    pass

--- a/bal_tools/subgraph.py
+++ b/bal_tools/subgraph.py
@@ -15,6 +15,7 @@ from bal_addresses import AddrBook
 from typing import Union, List, Callable, Dict
 from .utils import get_abi, flatten_nested_dict
 from .models import *
+from .errors import NoPricesFoundError
 
 
 graphql_base_path = f"{os.path.dirname(os.path.abspath(__file__))}/graphql"
@@ -285,7 +286,7 @@ class Subgraph:
                 if end_date_ts >= int(item["timestamp"]) >= start_date_ts
             ]
             if not prices:
-                raise ValueError(f"No prices found for {address}")
+                raise NoPricesFoundError(f"No prices found for {address} on {chain} between {start_date_ts} UTC and {end_date_ts} UTC")
             return TWAPResult(address=address, twap_price=sum(prices) / len(prices))
 
         results = [calc_twap(addr) for addr in addresses]

--- a/bal_tools/subgraph.py
+++ b/bal_tools/subgraph.py
@@ -97,7 +97,7 @@ class Subgraph:
                         if urlparse(url).scheme in ["http", "https"]:
                             graph_api_key = os.getenv("GRAPH_API_KEY")
                             if "${keys.graph}" in url and not graph_api_key:
-                                warnings.warn(f"`GRAPH_API_KEY` not set. may be rate limited or have stale data for subgraph:{subgraph} url:{url}")
+                                warnings.warn(f"`GRAPH_API_KEY` not set. may be rate limited or have stale data for subgraph:{subgraph} url:{url}", UserWarning)
                                 break
                             return url.replace("${keys.graph}", graph_api_key)
                     except AttributeError:

--- a/bal_tools/subgraph.py
+++ b/bal_tools/subgraph.py
@@ -97,7 +97,7 @@ class Subgraph:
                         if urlparse(url).scheme in ["http", "https"]:
                             graph_api_key = os.getenv("GRAPH_API_KEY")
                             if "${keys.graph}" in url and not graph_api_key:
-                                warnings.warn(f"`GRAPH_API_KEY` not set. may be rate limited for {url}")
+                                warnings.warn(f"`GRAPH_API_KEY` not set. may be rate limited or have stale data for subgraph:{subgraph} url:{url}")
                                 break
                             return url.replace("${keys.graph}", graph_api_key)
                     except AttributeError:

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -2,6 +2,7 @@ import os
 import pytest
 from decimal import Decimal
 import json
+import warnings
 
 from bal_tools.subgraph import (
     Subgraph,
@@ -82,3 +83,18 @@ def test_find_all_subgraph_urls(subgraph_all_chains, have_thegraph_key, subgraph
 
     assert url is not None
     assert url is not ""
+
+
+def test_warning_configuration(monkeypatch):
+    monkeypatch.setenv('GRAPH_API_KEY', '')
+    
+    # Should emit warning
+    with pytest.warns(UserWarning, match="calling .* without `GRAPH_API_KEY` set"):
+        subgraph = Subgraph(silence_warnings=False)
+        subgraph.get_subgraph_url("core")
+
+    # Should not emit warning
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        subgraph = Subgraph(silence_warnings=True)
+        subgraph.get_subgraph_url("core")

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -19,26 +19,26 @@ def date_range():
     return (1728190800, 1729400400)
 
 
-# @pytest.mark.skip
-# def test_get_first_block_after_utc_timestamp(chain, subgraph_all_chains):
-#     """
-#     currently not applicable as block api is not deterministic
-#     """
-#     if chain == "mainnet":
-#         block = subgraph_all_chains.get_first_block_after_utc_timestamp(1723117347)
-#         assert isinstance(block, int)
-#         assert block == 20483622
-#     else:
-#         pytest.skip(f"Skipping {chain}")
+@pytest.mark.skip
+def test_get_first_block_after_utc_timestamp(chain, subgraph_all_chains):
+    """
+    currently not applicable as block api is not deterministic
+    """
+    if chain == "mainnet":
+        block = subgraph_all_chains.get_first_block_after_utc_timestamp(1723117347)
+        assert isinstance(block, int)
+        assert block == 20483622
+    else:
+        pytest.skip(f"Skipping {chain}")
 
 
-# def test_invalid_chain():
-#     """
-#     we should get a raise when passing an invalid chain
-#     """
+def test_invalid_chain():
+    """
+    we should get a raise when passing an invalid chain
+    """
 
-#     with pytest.raises(ValueError):
-#         Subgraph("invalid_chain")
+    with pytest.raises(ValueError):
+        Subgraph("invalid_chain")
 
 
 def test_get_twap_prices(subgraph, date_range, mainnet_core_pools):
@@ -61,45 +61,45 @@ def test_get_twap_prices(subgraph, date_range, mainnet_core_pools):
             continue
 
 
-# def test_fetch_all_pools_info(subgraph):
-#     res = subgraph.fetch_all_pools_info()
-#     assert isinstance(res[0], Pool)
+def test_fetch_all_pools_info(subgraph):
+    res = subgraph.fetch_all_pools_info()
+    assert isinstance(res[0], Pool)
 
 
-# def test_get_balancer_pool_snapshots(chain, subgraph_all_chains, pool_snapshot_blocks):
-#     if chain in pool_snapshot_blocks.keys():
-#         block = pool_snapshot_blocks[chain]
-#         res = subgraph_all_chains.get_balancer_pool_snapshots(
-#             block, pools_per_req=25, limit=25
-#         )
+def test_get_balancer_pool_snapshots(chain, subgraph_all_chains, pool_snapshot_blocks):
+    if chain in pool_snapshot_blocks.keys():
+        block = pool_snapshot_blocks[chain]
+        res = subgraph_all_chains.get_balancer_pool_snapshots(
+            block, pools_per_req=25, limit=25
+        )
 
-#         assert isinstance(res[0], PoolSnapshot)
-#         assert all(isinstance(pool.totalProtocolFeePaidInBPT, Decimal) for pool in res)
-#         assert all(isinstance(pool.tokens[0].paidProtocolFees, Decimal) for pool in res)
-
-
-# @pytest.mark.parametrize("have_thegraph_key", [True, False])
-# @pytest.mark.parametrize("subgraph_type", ['core', 'gauges', 'blocks', 'aura'])
-# def test_find_all_subgraph_urls(subgraph_all_chains, have_thegraph_key, subgraph_type):
-#     if subgraph_all_chains.chain == 'sepolia' and subgraph_type in ['aura', 'blocks']:
-#         pytest.skip(f'No {subgraph_type} subgraph exists on Sepolia')
-#     os.environ['GRAPH_API_KEY'] = os.getenv('GRAPH_API_KEY') if have_thegraph_key else ""
-#     url = subgraph_all_chains.get_subgraph_url(subgraph_type)
-
-#     assert url is not None
-#     assert url is not ""
+        assert isinstance(res[0], PoolSnapshot)
+        assert all(isinstance(pool.totalProtocolFeePaidInBPT, Decimal) for pool in res)
+        assert all(isinstance(pool.tokens[0].paidProtocolFees, Decimal) for pool in res)
 
 
-# def test_warning_configuration(monkeypatch):
-#     monkeypatch.setenv('GRAPH_API_KEY', '')
+@pytest.mark.parametrize("have_thegraph_key", [True, False])
+@pytest.mark.parametrize("subgraph_type", ['core', 'gauges', 'blocks', 'aura'])
+def test_find_all_subgraph_urls(subgraph_all_chains, have_thegraph_key, subgraph_type):
+    if subgraph_all_chains.chain == 'sepolia' and subgraph_type in ['aura', 'blocks']:
+        pytest.skip(f'No {subgraph_type} subgraph exists on Sepolia')
+    os.environ['GRAPH_API_KEY'] = os.getenv('GRAPH_API_KEY') if have_thegraph_key else ""
+    url = subgraph_all_chains.get_subgraph_url(subgraph_type)
+
+    assert url is not None
+    assert url is not ""
+
+
+def test_warning_configuration(monkeypatch):
+    monkeypatch.setenv('GRAPH_API_KEY', '')
     
-#     # Should emit warning
-#     with pytest.warns(UserWarning):
-#         subgraph = Subgraph(silence_warnings=False)
-#         subgraph.get_subgraph_url("core")
+    # Should emit warning
+    with pytest.warns(UserWarning):
+        subgraph = Subgraph(silence_warnings=False)
+        subgraph.get_subgraph_url("core")
 
-#     # Should not emit warning
-#     with warnings.catch_warnings():
-#         warnings.simplefilter("error")
-#         subgraph = Subgraph(silence_warnings=True)
-#         subgraph.get_subgraph_url("core")
+    # Should not emit warning
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        subgraph = Subgraph(silence_warnings=True)
+        subgraph.get_subgraph_url("core")

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -89,7 +89,7 @@ def test_warning_configuration(monkeypatch):
     monkeypatch.setenv('GRAPH_API_KEY', '')
     
     # Should emit warning
-    with pytest.warns(UserWarning, match="calling .* without `GRAPH_API_KEY` set"):
+    with pytest.warns(UserWarning):
         subgraph = Subgraph(silence_warnings=False)
         subgraph.get_subgraph_url("core")
 

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -11,6 +11,7 @@ from bal_tools.subgraph import (
     PoolSnapshot,
     DateRange,
 )
+from bal_tools.errors import NoPricesFoundError
 
 
 @pytest.fixture(scope="module")
@@ -18,26 +19,26 @@ def date_range():
     return (1728190800, 1729400400)
 
 
-@pytest.mark.skip
-def test_get_first_block_after_utc_timestamp(chain, subgraph_all_chains):
-    """
-    currently not applicable as block api is not deterministic
-    """
-    if chain == "mainnet":
-        block = subgraph_all_chains.get_first_block_after_utc_timestamp(1723117347)
-        assert isinstance(block, int)
-        assert block == 20483622
-    else:
-        pytest.skip(f"Skipping {chain}")
+# @pytest.mark.skip
+# def test_get_first_block_after_utc_timestamp(chain, subgraph_all_chains):
+#     """
+#     currently not applicable as block api is not deterministic
+#     """
+#     if chain == "mainnet":
+#         block = subgraph_all_chains.get_first_block_after_utc_timestamp(1723117347)
+#         assert isinstance(block, int)
+#         assert block == 20483622
+#     else:
+#         pytest.skip(f"Skipping {chain}")
 
 
-def test_invalid_chain():
-    """
-    we should get a raise when passing an invalid chain
-    """
+# def test_invalid_chain():
+#     """
+#     we should get a raise when passing an invalid chain
+#     """
 
-    with pytest.raises(ValueError):
-        Subgraph("invalid_chain")
+#     with pytest.raises(ValueError):
+#         Subgraph("invalid_chain")
 
 
 def test_get_twap_prices(subgraph, date_range, mainnet_core_pools):
@@ -45,56 +46,60 @@ def test_get_twap_prices(subgraph, date_range, mainnet_core_pools):
         loaded_pool_prices = json.load(f)
 
     for pool_id, symbol in mainnet_core_pools:
-        prices = subgraph.get_twap_price_pool(
-            pool_id=pool_id,
-            chain=GqlChain.MAINNET,
-            date_range=date_range,
-        )
-        loaded_price = loaded_pool_prices.get(symbol)
-        if loaded_price:
-            assert pytest.approx(prices.bpt_price.twap_price, rel=Decimal(0.01)) == Decimal(loaded_price.get("bpt_price"))
-            for token_price, loaded_token_price in zip(prices.token_prices, loaded_price.get("token_prices")):
-                assert pytest.approx(token_price.twap_price, rel=Decimal(0.01)) == Decimal(loaded_token_price.get("twap_price"))
-
-def test_fetch_all_pools_info(subgraph):
-    res = subgraph.fetch_all_pools_info()
-    assert isinstance(res[0], Pool)
-
-
-def test_get_balancer_pool_snapshots(chain, subgraph_all_chains, pool_snapshot_blocks):
-    if chain in pool_snapshot_blocks.keys():
-        block = pool_snapshot_blocks[chain]
-        res = subgraph_all_chains.get_balancer_pool_snapshots(
-            block, pools_per_req=25, limit=25
-        )
-
-        assert isinstance(res[0], PoolSnapshot)
-        assert all(isinstance(pool.totalProtocolFeePaidInBPT, Decimal) for pool in res)
-        assert all(isinstance(pool.tokens[0].paidProtocolFees, Decimal) for pool in res)
+        try:
+            prices = subgraph.get_twap_price_pool(
+                pool_id=pool_id,
+                chain=GqlChain.MAINNET,
+                date_range=date_range,
+            )
+            loaded_price = loaded_pool_prices.get(symbol)
+            if loaded_price:
+                assert pytest.approx(prices.bpt_price.twap_price, rel=Decimal(0.01)) == Decimal(loaded_price.get("bpt_price"))
+                for token_price, loaded_token_price in zip(prices.token_prices, loaded_price.get("token_prices")):
+                    assert pytest.approx(token_price.twap_price, rel=Decimal(0.01)) == Decimal(loaded_token_price.get("twap_price"))
+        except NoPricesFoundError:
+            continue
 
 
-@pytest.mark.parametrize("have_thegraph_key", [True, False])
-@pytest.mark.parametrize("subgraph_type", ['core', 'gauges', 'blocks', 'aura'])
-def test_find_all_subgraph_urls(subgraph_all_chains, have_thegraph_key, subgraph_type):
-    if subgraph_all_chains.chain == 'sepolia' and subgraph_type in ['aura', 'blocks']:
-        pytest.skip(f'No {subgraph_type} subgraph exists on Sepolia')
-    os.environ['GRAPH_API_KEY'] = os.getenv('GRAPH_API_KEY') if have_thegraph_key else ""
-    url = subgraph_all_chains.get_subgraph_url(subgraph_type)
-
-    assert url is not None
-    assert url is not ""
+# def test_fetch_all_pools_info(subgraph):
+#     res = subgraph.fetch_all_pools_info()
+#     assert isinstance(res[0], Pool)
 
 
-def test_warning_configuration(monkeypatch):
-    monkeypatch.setenv('GRAPH_API_KEY', '')
+# def test_get_balancer_pool_snapshots(chain, subgraph_all_chains, pool_snapshot_blocks):
+#     if chain in pool_snapshot_blocks.keys():
+#         block = pool_snapshot_blocks[chain]
+#         res = subgraph_all_chains.get_balancer_pool_snapshots(
+#             block, pools_per_req=25, limit=25
+#         )
+
+#         assert isinstance(res[0], PoolSnapshot)
+#         assert all(isinstance(pool.totalProtocolFeePaidInBPT, Decimal) for pool in res)
+#         assert all(isinstance(pool.tokens[0].paidProtocolFees, Decimal) for pool in res)
+
+
+# @pytest.mark.parametrize("have_thegraph_key", [True, False])
+# @pytest.mark.parametrize("subgraph_type", ['core', 'gauges', 'blocks', 'aura'])
+# def test_find_all_subgraph_urls(subgraph_all_chains, have_thegraph_key, subgraph_type):
+#     if subgraph_all_chains.chain == 'sepolia' and subgraph_type in ['aura', 'blocks']:
+#         pytest.skip(f'No {subgraph_type} subgraph exists on Sepolia')
+#     os.environ['GRAPH_API_KEY'] = os.getenv('GRAPH_API_KEY') if have_thegraph_key else ""
+#     url = subgraph_all_chains.get_subgraph_url(subgraph_type)
+
+#     assert url is not None
+#     assert url is not ""
+
+
+# def test_warning_configuration(monkeypatch):
+#     monkeypatch.setenv('GRAPH_API_KEY', '')
     
-    # Should emit warning
-    with pytest.warns(UserWarning):
-        subgraph = Subgraph(silence_warnings=False)
-        subgraph.get_subgraph_url("core")
+#     # Should emit warning
+#     with pytest.warns(UserWarning):
+#         subgraph = Subgraph(silence_warnings=False)
+#         subgraph.get_subgraph_url("core")
 
-    # Should not emit warning
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        subgraph = Subgraph(silence_warnings=True)
-        subgraph.get_subgraph_url("core")
+#     # Should not emit warning
+#     with warnings.catch_warnings():
+#         warnings.simplefilter("error")
+#         subgraph = Subgraph(silence_warnings=True)
+#         subgraph.get_subgraph_url("core")


### PR DESCRIPTION
#55 also adds silence_warnings option to subgraph init as to not spam users who are conscious of not having an api key set. tests also included

additionally modified get_twap_price_pool to raise `NoPricesFoundError` when there is incomplete price data so tests can gracefully catch this instead of failing