### PR TITLE
test: cache and restore graph api key

### DIFF
--- a/bal_tools/subgraph.py
+++ b/bal_tools/subgraph.py
@@ -211,15 +211,12 @@ class Subgraph:
                     )
 
         transport = RequestsHTTPTransport(
-            url=url or self.subgraph_url[subgraph], retries=retries
-        )
-        client = Client(
-            transport=transport,
-            fetch_schema_from_transport=False,
-            retries=2,
+            url=url or self.subgraph_url[subgraph],
+            retries=retries,
             retry_backoff_factor=0.5,
             retry_status_forcelist=[429, 500, 502, 503, 504, 520],
         )
+        client = Client(transport=transport, fetch_schema_from_transport=False)
 
         # retrieve the query from its file and execute it
         with open(f"{graphql_base_path}/{subgraph}/{query}.gql") as f:

--- a/bal_tools/subgraph.py
+++ b/bal_tools/subgraph.py
@@ -213,7 +213,13 @@ class Subgraph:
         transport = RequestsHTTPTransport(
             url=url or self.subgraph_url[subgraph], retries=retries
         )
-        client = Client(transport=transport, fetch_schema_from_transport=False)
+        client = Client(
+            transport=transport,
+            fetch_schema_from_transport=False,
+            retries=2,
+            retry_backoff_factor=0.5,
+            retry_status_forcelist=[429, 500, 502, 503, 504, 520],
+        )
 
         # retrieve the query from its file and execute it
         with open(f"{graphql_base_path}/{subgraph}/{query}.gql") as f:

--- a/bal_tools/subgraph.py
+++ b/bal_tools/subgraph.py
@@ -40,8 +40,14 @@ class Subgraph:
         self.chain = chain
         self.subgraph_url = {}
         if silence_warnings:
-            warnings.filterwarnings('ignore', module='bal_tools.subgraph')
+            self.set_silence_warnings(True)
         self.custom_price_logic: Dict[str, Callable] = {}
+
+    def set_silence_warnings(self, silence_warnings: bool):
+        if silence_warnings:
+            warnings.filterwarnings("ignore", module="bal_tools.subgraph")
+        else:
+            warnings.filterwarnings("default", module="bal_tools.subgraph")
 
     def get_subgraph_url(self, subgraph="core") -> str:
         """
@@ -93,7 +99,10 @@ class Subgraph:
                         if urlparse(url).scheme in ["http", "https"]:
                             graph_api_key = os.getenv("GRAPH_API_KEY")
                             if "${keys.graph}" in url and not graph_api_key:
-                                warnings.warn(f"`GRAPH_API_KEY` not set. may be rate limited or have stale data for subgraph:{subgraph} url:{url}", UserWarning)
+                                warnings.warn(
+                                    f"`GRAPH_API_KEY` not set. may be rate limited or have stale data for subgraph:{subgraph} url:{url}",
+                                    UserWarning,
+                                )
                                 break
                             return url.replace("${keys.graph}", graph_api_key)
                     except AttributeError:
@@ -281,7 +290,9 @@ class Subgraph:
                 if end_date_ts >= int(item["timestamp"]) >= start_date_ts
             ]
             if not prices:
-                raise NoPricesFoundError(f"No prices found for {address} on {chain} between {start_date_ts} UTC and {end_date_ts} UTC")
+                raise NoPricesFoundError(
+                    f"No prices found for {address} on {chain} between {start_date_ts} UTC and {end_date_ts} UTC"
+                )
             return TWAPResult(address=address, twap_price=sum(prices) / len(prices))
 
         results = [calc_twap(addr) for addr in addresses]

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -82,7 +82,9 @@ def test_get_balancer_pool_snapshots(chain, subgraph_all_chains, pool_snapshot_b
 
 @pytest.mark.parametrize("have_thegraph_key", [True, False])
 @pytest.mark.parametrize("subgraph_type", ["core", "gauges", "blocks", "aura"])
-def test_find_all_subgraph_urls(subgraph_all_chains, have_thegraph_key, subgraph_type):
+def test_find_all_subgraph_urls(
+    subgraph_all_chains, have_thegraph_key, subgraph_type, monkeypatch
+):
     if subgraph_all_chains.chain in ["sepolia", "mode"] and subgraph_type in [
         "aura",
         "blocks",
@@ -92,9 +94,7 @@ def test_find_all_subgraph_urls(subgraph_all_chains, have_thegraph_key, subgraph
         )
 
     if not have_thegraph_key:
-        # temporarily remove the key
-        cached_graph_api_key = os.environ["GRAPH_API_KEY"]
-        os.environ["GRAPH_API_KEY"] = ""
+        monkeypatch.setenv("GRAPH_API_KEY", "")
         subgraph_all_chains.set_silence_warnings(True)
 
     url = subgraph_all_chains.get_subgraph_url(subgraph_type)
@@ -103,8 +103,6 @@ def test_find_all_subgraph_urls(subgraph_all_chains, have_thegraph_key, subgraph
     assert url is not ""
 
     if not have_thegraph_key:
-        # restore the key
-        os.environ["GRAPH_API_KEY"] = cached_graph_api_key
         subgraph_all_chains.set_silence_warnings(False)
 
 

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -90,13 +90,22 @@ def test_find_all_subgraph_urls(subgraph_all_chains, have_thegraph_key, subgraph
         pytest.skip(
             f"No {subgraph_type} subgraph exists on {subgraph_all_chains.chain}"
         )
-    os.environ["GRAPH_API_KEY"] = (
-        os.getenv("GRAPH_API_KEY") if have_thegraph_key else ""
-    )
+
+    if not have_thegraph_key:
+        # temporarily remove the key
+        cached_graph_api_key = os.environ["GRAPH_API_KEY"]
+        os.environ["GRAPH_API_KEY"] = ""
+        subgraph_all_chains.set_silence_warnings(True)
+
     url = subgraph_all_chains.get_subgraph_url(subgraph_type)
 
     assert url is not None
     assert url is not ""
+
+    if not have_thegraph_key:
+        # restore the key
+        os.environ["GRAPH_API_KEY"] = cached_graph_api_key
+        subgraph_all_chains.set_silence_warnings(False)
 
 
 def test_warning_configuration(monkeypatch):


### PR DESCRIPTION
fix logic flaw that actually throws away the graph api key when testing a subgraph instance that doesnt have the key