### PR TITLE
SafeTxBuilder: preserve abi type definitions/components in payload

### DIFF
--- a/bal_tools/safe_tx_builder/abi.py
+++ b/bal_tools/safe_tx_builder/abi.py
@@ -7,7 +7,7 @@ class InputType:
     name: str
     type: str
     internalType: Optional[str] = None
-    components: Optional[List['InputType']] = None
+    components: Optional[List["InputType"]] = None
 
 
 @dataclass
@@ -30,7 +30,7 @@ def parse_input_type(input_desc: dict) -> InputType:
     name = input_desc.get("name", "")
     type_str = input_desc.get("type", "")
     internal_type = input_desc.get("internalType", type_str)
-    
+
     # Preserve components for tuple types
     components = None
     if type_str.startswith("tuple"):
@@ -38,12 +38,9 @@ def parse_input_type(input_desc: dict) -> InputType:
         # Recursively parse nested components
         if components_raw:
             components = [parse_input_type(comp) for comp in components_raw]
-    
+
     return InputType(
-        name=name,
-        type=type_str,
-        internalType=internal_type,
-        components=components
+        name=name, type=type_str, internalType=internal_type, components=components
     )
 
 

--- a/bal_tools/safe_tx_builder/abi.py
+++ b/bal_tools/safe_tx_builder/abi.py
@@ -6,6 +6,8 @@ from typing import List, Optional
 class InputType:
     name: str
     type: str
+    internalType: Optional[str] = None
+    components: Optional[List['InputType']] = None
 
 
 @dataclass
@@ -23,18 +25,36 @@ class ContractABI:
     name: Optional[str] = None
 
 
+def parse_input_type(input_desc: dict) -> InputType:
+    """Parse input type preserving component structure for tuples."""
+    name = input_desc.get("name", "")
+    type_str = input_desc.get("type", "")
+    internal_type = input_desc.get("internalType", type_str)
+    
+    # Preserve components for tuple types
+    components = None
+    if type_str.startswith("tuple"):
+        components_raw = input_desc.get("components", [])
+        # Recursively parse nested components
+        if components_raw:
+            components = [parse_input_type(comp) for comp in components_raw]
+    
+    return InputType(
+        name=name,
+        type=type_str,
+        internalType=internal_type,
+        components=components
+    )
+
+
 def parse_json_abi(abi: dict) -> ContractABI:
     functions = []
     for entry in abi:
         if entry["type"] == "function":
             name = entry["name"]
-            input_types = [collapse_if_tuple(inputs) for inputs in entry["inputs"]]
-            input_names = [i["name"] for i in entry["inputs"]]
-            inputs = [
-                InputType(name=name, type=typ)
-                for name, typ in zip(input_names, input_types)
-            ]
-            outputs = [collapse_if_tuple(outputs) for outputs in entry["outputs"]]
+            # Parse inputs preserving structure
+            inputs = [parse_input_type(inp) for inp in entry["inputs"]]
+            outputs = [o.get("type", "") for o in entry["outputs"]]
             constant = entry["stateMutability"] in ("view", "pure")
             payable = entry["stateMutability"] == "payable"
             functions.append(
@@ -47,17 +67,3 @@ def parse_json_abi(abi: dict) -> ContractABI:
                 )
             )
     return ContractABI(functions)
-
-
-def collapse_if_tuple(abi: dict) -> str:
-    typ = abi["type"]
-    if not typ.startswith("tuple"):
-        return typ
-
-    delimited = ",".join(collapse_if_tuple(c) for c in abi["components"])
-    # Whatever comes after "tuple" is the array dims.  The ABI spec states that
-    # this will have the form "", "[]", or "[k]".
-    array_dim = typ[5:]
-    collapsed = "({}){}".format(delimited, array_dim)
-
-    return collapsed

--- a/bal_tools/safe_tx_builder/models.py
+++ b/bal_tools/safe_tx_builder/models.py
@@ -19,6 +19,7 @@ class InputType(BaseModel):
     name: str = Field(default="")
     type: str = Field(default="")
     internalType: str = Field(default="")
+    components: Optional[List['InputType']] = Field(default=None)
 
 
 class ContractMethod(BaseModel):

--- a/bal_tools/safe_tx_builder/models.py
+++ b/bal_tools/safe_tx_builder/models.py
@@ -19,7 +19,7 @@ class InputType(BaseModel):
     name: str = Field(default="")
     type: str = Field(default="")
     internalType: str = Field(default="")
-    components: Optional[List['InputType']] = Field(default=None)
+    components: Optional[List["InputType"]] = Field(default=None)
 
 
 class ContractMethod(BaseModel):

--- a/bal_tools/safe_tx_builder/safe_contract.py
+++ b/bal_tools/safe_tx_builder/safe_contract.py
@@ -58,6 +58,20 @@ class SafeContract:
             return str(value)
         except Exception as e:
             raise ValueError(f"Failed to convert value to string: {e}")
+    
+    def _convert_components_to_dict(self, components):
+        result = []
+        for comp in components:
+            comp_dict = {
+                "name": comp.name,
+                "type": comp.type,
+                "internalType": comp.internalType or comp.type
+            }
+            # Recursively handle nested components
+            if hasattr(comp, 'components') and comp.components:
+                comp_dict["components"] = self._convert_components_to_dict(comp.components)
+            result.append(comp_dict)
+        return result
 
     def call_function(self, func: ABIFunction, args: tuple, kwargs: dict = {}):
         if func.constant:
@@ -79,7 +93,11 @@ class SafeContract:
             input_template = self.tx_builder.load_template(TemplateType.INPUT_TYPE)
             input_template.name = input_type.name
             input_template.type = input_type.type
-            input_template.internalType = input_type.type
+            input_template.internalType = input_type.internalType or input_type.type
+            
+            if hasattr(input_type, 'components') and input_type.components:
+                input_template.components = self._convert_components_to_dict(input_type.components)
+            
             tx.contractMethod.inputs.append(input_template)
             tx.contractInputsValues[input_type.name] = self._handle_type(arg)
 

--- a/bal_tools/safe_tx_builder/safe_contract.py
+++ b/bal_tools/safe_tx_builder/safe_contract.py
@@ -66,11 +66,13 @@ class SafeContract:
             input_type.name = comp.name
             input_type.type = comp.type
             input_type.internalType = comp.internalType or comp.type
-            
+
             # Recursively handle nested components
-            if hasattr(comp, 'components') and comp.components:
-                input_type.components = self._convert_components_to_inputtype(comp.components)
-            
+            if hasattr(comp, "components") and comp.components:
+                input_type.components = self._convert_components_to_inputtype(
+                    comp.components
+                )
+
             result.append(input_type)
         return result
 
@@ -95,10 +97,12 @@ class SafeContract:
             input_template.name = input_type.name
             input_template.type = input_type.type
             input_template.internalType = input_type.internalType or input_type.type
-            
-            if hasattr(input_type, 'components') and input_type.components:
-                input_template.components = self._convert_components_to_inputtype(input_type.components)
-            
+
+            if hasattr(input_type, "components") and input_type.components:
+                input_template.components = self._convert_components_to_inputtype(
+                    input_type.components
+                )
+
             tx.contractMethod.inputs.append(input_template)
             tx.contractInputsValues[input_type.name] = self._handle_type(arg)
 

--- a/bal_tools/safe_tx_builder/safe_contract.py
+++ b/bal_tools/safe_tx_builder/safe_contract.py
@@ -58,18 +58,20 @@ class SafeContract:
             return str(value)
         except Exception as e:
             raise ValueError(f"Failed to convert value to string: {e}")
-    
+
     def _convert_components_to_dict(self, components):
         result = []
         for comp in components:
             comp_dict = {
                 "name": comp.name,
                 "type": comp.type,
-                "internalType": comp.internalType or comp.type
+                "internalType": comp.internalType or comp.type,
             }
             # Recursively handle nested components
-            if hasattr(comp, 'components') and comp.components:
-                comp_dict["components"] = self._convert_components_to_dict(comp.components)
+            if hasattr(comp, "components") and comp.components:
+                comp_dict["components"] = self._convert_components_to_dict(
+                    comp.components
+                )
             result.append(comp_dict)
         return result
 
@@ -94,10 +96,12 @@ class SafeContract:
             input_template.name = input_type.name
             input_template.type = input_type.type
             input_template.internalType = input_type.internalType or input_type.type
-            
-            if hasattr(input_type, 'components') and input_type.components:
-                input_template.components = self._convert_components_to_dict(input_type.components)
-            
+
+            if hasattr(input_type, "components") and input_type.components:
+                input_template.components = self._convert_components_to_dict(
+                    input_type.components
+                )
+
             tx.contractMethod.inputs.append(input_template)
             tx.contractInputsValues[input_type.name] = self._handle_type(arg)
 

--- a/bal_tools/safe_tx_builder/safe_tx_builder.py
+++ b/bal_tools/safe_tx_builder/safe_tx_builder.py
@@ -78,6 +78,6 @@ class SafeTxBuilder:
         returns the payload
         """
         with open(output_file, "w") as f:
-            f.write(self.base_payload.model_dump_json(indent=2))
+            f.write(self.base_payload.model_dump_json(indent=2, exclude_none=True))
 
         return self.base_payload

--- a/tests/abi/RewardDistributor.json
+++ b/tests/abi/RewardDistributor.json
@@ -1,0 +1,541 @@
+[
+    {
+        "inputs": [],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidArray",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidDistribution",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidMerkleRoot",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidProof",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidTimerDuration",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "RewardInactive",
+        "type": "error"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "Paused",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "identifier",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "token",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "RewardClaimed",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "identifier",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "token",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "merkleRoot",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "proof",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "activeAt",
+                "type": "uint256"
+            }
+        ],
+        "name": "RewardMetadataUpdated",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "previousAdminRole",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "newAdminRole",
+                "type": "bytes32"
+            }
+        ],
+        "name": "RoleAdminChanged",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "RoleGranted",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "RoleRevoked",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "duration",
+                "type": "uint256"
+            }
+        ],
+        "name": "SetActiveTimerDuration",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "Unpaused",
+        "type": "event"
+    },
+    {
+        "inputs": [],
+        "name": "DEFAULT_ADMIN_ROLE",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "MINIMUM_ACTIVE_TIMER",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "activeTimerDuration",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_duration",
+                "type": "uint256"
+            }
+        ],
+        "name": "changeActiveTimerDuration",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "bytes32",
+                        "name": "identifier",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "account",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "amount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "bytes32[]",
+                        "name": "merkleProof",
+                        "type": "bytes32[]"
+                    }
+                ],
+                "internalType": "struct RewardDistributor.Claim[]",
+                "name": "_claims",
+                "type": "tuple[]"
+            }
+        ],
+        "name": "claim",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "claimed",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            }
+        ],
+        "name": "getRoleAdmin",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "grantRole",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "hasRole",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "paused",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "renounceRole",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "revokeRole",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "name": "rewards",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "token",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "merkleRoot",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "proof",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "uint256",
+                "name": "activeAt",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bool",
+                "name": "state",
+                "type": "bool"
+            }
+        ],
+        "name": "setPauseState",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "interfaceId",
+                "type": "bytes4"
+            }
+        ],
+        "name": "supportsInterface",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "bytes32",
+                        "name": "identifier",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "merkleRoot",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "proof",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct Common.Distribution[]",
+                "name": "_distributions",
+                "type": "tuple[]"
+            }
+        ],
+        "name": "updateRewardsMetadata",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    }
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,12 @@ def bridge_abi():
 
 
 @pytest.fixture(scope="module")
+def reward_distributor_abi():
+    with open("tests/abi/RewardDistributor.json", "r") as file:
+        return json.load(file)
+
+
+@pytest.fixture(scope="module")
 def pool_snapshot_blocks():
     return {
         "arbitrum": 200000000,

--- a/tests/test_safe_tx_builder.py
+++ b/tests/test_safe_tx_builder.py
@@ -106,22 +106,22 @@ def test_tuple_type_preservation(reward_distributor_abi):
     ), "Should have 4 components in the Claim struct"
 
     components = claim_input.components
-    
+
     assert components[0].name == "identifier"
     assert components[0].type == "bytes32"
     assert components[0].internalType == "bytes32"
     assert components[0].components is None
-    
+
     assert components[1].name == "account"
     assert components[1].type == "address"
     assert components[1].internalType == "address"
     assert components[1].components is None
-    
+
     assert components[2].name == "amount"
     assert components[2].type == "uint256"
     assert components[2].internalType == "uint256"
     assert components[2].components is None
-    
+
     assert components[3].name == "merkleProof"
     assert components[3].type == "bytes32[]"
     assert components[3].internalType == "bytes32[]"
@@ -130,16 +130,19 @@ def test_tuple_type_preservation(reward_distributor_abi):
     # Verify the input values are correctly stored
     assert "_claims" in tx.contractInputsValues
     assert tx.contractInputsValues["_claims"] == str(claims)
-    
+
     # Test JSON serialization excludes None components
     import json
+
     json_output = json.loads(builder.base_payload.model_dump_json(exclude_none=True))
     tx_json = json_output["transactions"][0]
     claim_input_json = tx_json["contractMethod"]["inputs"][0]
-    
+
     # Tuple type should have components
     assert "components" in claim_input_json
-    
+
     # Non-tuple components should NOT have the components field at all
     for component_json in claim_input_json["components"]:
-        assert "components" not in component_json, f"Non-tuple type {component_json['type']} should not have components field in JSON"
+        assert (
+            "components" not in component_json
+        ), f"Non-tuple type {component_json['type']} should not have components field in JSON"

--- a/tests/test_safe_tx_builder.py
+++ b/tests/test_safe_tx_builder.py
@@ -64,9 +64,11 @@ def test_tuple_type_preservation(reward_distributor_abi):
     """Test that tuple types with components are preserved in the output, not collapsed."""
     builder = SafeTxBuilder("0x10A19e7eE7d7F8a52822f6817de8ea18204F2e4f")
     reward_distributor_address = "0x0000000000000000000000000000000000000001"
-    
-    reward_distributor = SafeContract(reward_distributor_address, reward_distributor_abi)
-    
+
+    reward_distributor = SafeContract(
+        reward_distributor_address, reward_distributor_abi
+    )
+
     claims = [
         [
             "0x1234567890123456789012345678901234567890123456789012345678901234",
@@ -74,33 +76,35 @@ def test_tuple_type_preservation(reward_distributor_abi):
             1000000000000000000,
             [
                 "0xabcdef1234567890123456789012345678901234567890123456789012345678",
-                "0xfedcba0987654321098765432109876543210987654321098765432109876543"
-            ]
+                "0xfedcba0987654321098765432109876543210987654321098765432109876543",
+            ],
         ]
     ]
     reward_distributor.claim(claims)
-    
+
     payload = builder.base_payload
-    
+
     assert len(payload.transactions) == 1
     tx = payload.transactions[0]
-    
+
     assert tx.to == reward_distributor_address
     assert tx.contractMethod.name == "claim"
-    
+
     # Verify the input has the correct type (tuple[])
     assert len(tx.contractMethod.inputs) == 1
     claim_input = tx.contractMethod.inputs[0]
-    
+
     # Check that the type is preserved as "tuple[]"
     assert claim_input.name == "_claims"
     assert claim_input.type == "tuple[]"
     assert claim_input.internalType == "struct RewardDistributor.Claim[]"
-    
-    assert hasattr(claim_input, 'components'), "Input should have components attribute"
+
+    assert hasattr(claim_input, "components"), "Input should have components attribute"
     assert claim_input.components is not None, "Components should not be None"
-    assert len(claim_input.components) == 4, "Should have 4 components in the Claim struct"
-    
+    assert (
+        len(claim_input.components) == 4
+    ), "Should have 4 components in the Claim struct"
+
     # Verify the input values are correctly stored
     assert "_claims" in tx.contractInputsValues
     assert tx.contractInputsValues["_claims"] == str(claims)

--- a/tests/test_safe_tx_builder.py
+++ b/tests/test_safe_tx_builder.py
@@ -105,6 +105,41 @@ def test_tuple_type_preservation(reward_distributor_abi):
         len(claim_input.components) == 4
     ), "Should have 4 components in the Claim struct"
 
+    components = claim_input.components
+    
+    assert components[0].name == "identifier"
+    assert components[0].type == "bytes32"
+    assert components[0].internalType == "bytes32"
+    assert components[0].components is None
+    
+    assert components[1].name == "account"
+    assert components[1].type == "address"
+    assert components[1].internalType == "address"
+    assert components[1].components is None
+    
+    assert components[2].name == "amount"
+    assert components[2].type == "uint256"
+    assert components[2].internalType == "uint256"
+    assert components[2].components is None
+    
+    assert components[3].name == "merkleProof"
+    assert components[3].type == "bytes32[]"
+    assert components[3].internalType == "bytes32[]"
+    assert components[3].components is None
+
     # Verify the input values are correctly stored
     assert "_claims" in tx.contractInputsValues
     assert tx.contractInputsValues["_claims"] == str(claims)
+    
+    # Test JSON serialization excludes None components
+    import json
+    json_output = json.loads(builder.base_payload.model_dump_json(exclude_none=True))
+    tx_json = json_output["transactions"][0]
+    claim_input_json = tx_json["contractMethod"]["inputs"][0]
+    
+    # Tuple type should have components
+    assert "components" in claim_input_json
+    
+    # Non-tuple components should NOT have the components field at all
+    for component_json in claim_input_json["components"]:
+        assert "components" not in component_json, f"Non-tuple type {component_json['type']} should not have components field in JSON"

--- a/tests/test_safe_tx_builder.py
+++ b/tests/test_safe_tx_builder.py
@@ -58,3 +58,49 @@ def test_multiple_functions_with_same_name(bridge_abi):
     bridge.relayTokens(usdc_address, int(1e18))
 
     builder.output_payload("tests/payload_outputs/multiple_names.json")
+
+
+def test_tuple_type_preservation(reward_distributor_abi):
+    """Test that tuple types with components are preserved in the output, not collapsed."""
+    builder = SafeTxBuilder("0x10A19e7eE7d7F8a52822f6817de8ea18204F2e4f")
+    reward_distributor_address = "0x0000000000000000000000000000000000000001"
+    
+    reward_distributor = SafeContract(reward_distributor_address, reward_distributor_abi)
+    
+    claims = [
+        [
+            "0x1234567890123456789012345678901234567890123456789012345678901234",
+            "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            1000000000000000000,
+            [
+                "0xabcdef1234567890123456789012345678901234567890123456789012345678",
+                "0xfedcba0987654321098765432109876543210987654321098765432109876543"
+            ]
+        ]
+    ]
+    reward_distributor.claim(claims)
+    
+    payload = builder.base_payload
+    
+    assert len(payload.transactions) == 1
+    tx = payload.transactions[0]
+    
+    assert tx.to == reward_distributor_address
+    assert tx.contractMethod.name == "claim"
+    
+    # Verify the input has the correct type (tuple[])
+    assert len(tx.contractMethod.inputs) == 1
+    claim_input = tx.contractMethod.inputs[0]
+    
+    # Check that the type is preserved as "tuple[]"
+    assert claim_input.name == "_claims"
+    assert claim_input.type == "tuple[]"
+    assert claim_input.internalType == "struct RewardDistributor.Claim[]"
+    
+    assert hasattr(claim_input, 'components'), "Input should have components attribute"
+    assert claim_input.components is not None, "Components should not be None"
+    assert len(claim_input.components) == 4, "Should have 4 components in the Claim struct"
+    
+    # Verify the input values are correctly stored
+    assert "_claims" in tx.contractInputsValues
+    assert tx.contractInputsValues["_claims"] == str(claims)


### PR DESCRIPTION
when outputting a payload from a `SafeContract`,  previously components/types were not preserved from the ABI it was initialized with. this fixes that

this is needed in order for the Safe app to properly encode payload values 

effectively changes the payload contract method definition from:
```json
  {
    "contractMethod": {
      "inputs": [{
        "name": "_claims",
        "type": "(bytes32,address,uint256,bytes32[])[]",
        "internalType": "(bytes32,address,uint256,bytes32[])[]"
      }]
    }
  }
```
to:
```json
  {
    "contractMethod": {
      "inputs": [{
        "name": "_claims",
        "type": "tuple[]",
        "internalType": "struct RewardDistributor.Claim[]",
        "components": [
          {"name": "identifier", "type": "bytes32", "internalType": "bytes32"},
          {"name": "account", "type": "address", "internalType": "address"},
          {"name": "amount", "type": "uint256", "internalType": "uint256"},
          {"name": "merkleProof", "type": "bytes32[]", "internalType": "bytes32[]"}
        ]
      }]
    }
  }
  ```