### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python_package.yaml
+++ b/.github/workflows/python_package.yaml
@@ -1,4 +1,6 @@
 name: Python package
+permissions:
+  contents: read
 
 on: [pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/BalancerMaxis/bal_tools/security/code-scanning/1](https://github.com/BalancerMaxis/bal_tools/security/code-scanning/1)

To fix the problem, we need to specify the least privileges needed for the workflow by adding an explicit `permissions` block. The minimal permission required for actions like checking out code and installing dependencies from the repository is `contents: read`. This block should be added at the root level of the workflow YAML file, just below the `name:` and above the `on:` key (as recommended by GitHub's documentation), so it applies to all jobs unless individually overridden. No changes to existing functionality or any step are required—just the addition of the `permissions:` line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
