### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -5,6 +5,8 @@ on: [pull_request]
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/BalancerMaxis/bal_tools/security/code-scanning/4](https://github.com/BalancerMaxis/bal_tools/security/code-scanning/4)

To address this issue, a `permissions` block should be added to the workflow specifying the minimum required privileges for the job. Since the "Auto commit" step requires write access to repository contents, the job needs `contents: write` permissions. A good practice is to add the `permissions` block at the job level (under `lint:`, at the same indentation as `runs-on:`), ensuring only this job gets the required permissions and not other jobs if multiple existed. No additional imports or methods are necessary; the fix is a simple addition to the workflow YAML, after the job name and before the first step.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
