### PR TITLE
filter anomalous price data from twap price

### DIFF
--- a/bal_tools/subgraph.py
+++ b/bal_tools/subgraph.py
@@ -394,7 +394,9 @@ class Subgraph:
                 f"Failed to fetch block for timestamp {timestamp} on {self.chain}: {str(e)}"
             )
 
-    def filter_outliers_and_average(self, prices: List[Decimal], iqr_multiplier: float = 100_000.0) -> Decimal:
+    def filter_outliers_and_average(
+        self, prices: List[Decimal], iqr_multiplier: float = 100_000.0
+    ) -> Decimal:
         arr = np.array([float(p) for p in prices])
 
         if len(arr) == 1:

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -210,14 +210,14 @@ def test_get_first_block_after_utc_timestamp_with_etherscan(
 def test_siusd_outlier_price_handling():
     subgraph = Subgraph()
     siusd_address = "0xdbdc1ef57537e34680b898e1febd3d68c7389bcb"
-    
+
     # inclusive of corrupted timestamp at 1756807200
     date_range = (1756684800, 1756944000)
 
     result = subgraph.get_twap_price_token(
-        addresses=siusd_address,
-        chain=GqlChain.MAINNET,
-        date_range=date_range
+        addresses=siusd_address, chain=GqlChain.MAINNET, date_range=date_range
     )
 
-    assert result.twap_price < Decimal("10"), f"TWAP price {result.twap_price} suggests corruption wasn't filtered"
+    assert result.twap_price < Decimal(
+        "10"
+    ), f"TWAP price {result.twap_price} suggests corruption wasn't filtered"


### PR DESCRIPTION
add a new `filter_outliers_and_average` method for `get_twap_price_pool` which uses IQR to filter anomalous/incorrect price data by:
1. sort price data by price and calculate 1st and 3rd percentile
2. iqr = q3 - q1 (spread of the middle 50% of data)
3. creates lower bounds of `q1 - iqr_multiplier*iqr` and upper bound of `q3 + iqr_multiplier*iqr`
4. filters price data outside of those bounds

a `iqr_multiplier` value of 100,00 is used. this is pretty arbitrary but is set to be very high to avoid incorrectly filtering out *legit* outliers and only filtering out obviously incorrect outliers sourced from data side