### PR TITLE
fix: preserve lists/arrays in `SafeContract` parameter handling

### DIFF
--- a/bal_tools/safe_tx_builder/safe_contract.py
+++ b/bal_tools/safe_tx_builder/safe_contract.py
@@ -78,6 +78,9 @@ class SafeContract:
                 return json.dumps(formatted_list, separators=(",", ":"))
 
         try:
+            # Keep lists/arrays as-is for proper JSON serialization
+            if isinstance(value, (list, tuple)):
+                return value
             if isinstance(value, float):
                 value = int(value)
             return str(value)


### PR DESCRIPTION
creates issues with tenderly sim otherwise, as seen in https://github.com/BalancerMaxis/multisig-ops/pull/2498