### PR TITLE
fix: escape ternary exprs

### DIFF
--- a/bal_tools/ts_config_loader.py
+++ b/bal_tools/ts_config_loader.py
@@ -323,7 +323,8 @@ def _to_json(obj: str) -> str:
     obj = handle_ternary(obj)
 
     # 6e) Handle environment variable references like env.PAXOS_APR_KEY
-    obj = re.sub(r"\benv\.[A-Z_][A-Z0-9_]*\b", "null", obj)
+    # BUT preserve ${env.VAR} template interpolations - these are handled by get_subgraph_url_from_backend_config
+    obj = re.sub(r"(?<!\$\{)(?<!\{)\benv\.[A-Z_][A-Z0-9_]*\b", "null", obj)
 
     # 8) Clean up any stray parentheses from map function conversions
     # Only clean up )) that come immediately after } or ] without any other content


### PR DESCRIPTION
current test suite is failing because of this: https://github.com/BalancerMaxis/bal_tools/actions/runs/19555583135/job/56335117203?pr=147