### PR TITLE
fix: remove deprecated snapshots field from get_v3_fees query

### DIFF
--- a/bal_tools/graphql/vault-v3/get_v3_fees.gql
+++ b/bal_tools/graphql/vault-v3/get_v3_fees.gql
@@ -9,11 +9,5 @@ query GetV3Fees($poolId: ID!) {
       vaultProtocolYieldFeeBalance
       controllerProtocolFeeBalance
     }
-    snapshots(first: 1, orderBy: timestamp, orderDirection: desc) {
-      timestamp
-      balances
-      totalProtocolSwapFees
-      totalProtocolYieldFees
-    }
   }
 }


### PR DESCRIPTION
The V3 subgraph no longer exposes `snapshots` on the `Pool` type, causing all callers of this query to fail with:

```
Type `Pool` has no field `snapshots`
```

The snapshot data was unused by known consumers (e.g. v3 fee bot). Similar to #163 which removed the `poolSnapshots` dependency from `get_protocol_fees`.